### PR TITLE
add dtd2mysql

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,7 @@ Software that makes it easy to consume GTFS data in a variety of languages.
 Converters from various static schedule formats to and from GTFS.
 
 - [Chouette](https://bitbucket.org/enroute-mobi/chouette-core/src/master/) - Converts French-Transmodel, SIRI, NETeX.
+- [dtd2mysql](https://github.com/planarnetwork/dtd2mysql) - Tool for importing British Rail timetable in CIF format into MySQL and exporting to GTFS.
 - [extract-gtfs-pathways](https://github.com/derhuerst/extract-gtfs-pathways) – Command-line tool to extract pathways as GeoJSON from a GTFS dataset.
 - [extract-gtfs-shapes](https://github.com/derhuerst/extract-gtfs-shapes) – Command-line tool to extract shapes as GeoJSON from a GTFS dataset.
 - [GTFS-OSM-Sync](https://github.com/CUTR-at-USF/gtfs-osm-sync) - A Java tool for synchronizing data in GTFS format with [OpenStreetMap.org](http://www.openstreetmap.org/).


### PR DESCRIPTION
dtd2mysql is a tool to import British Rail timetable in CIF format into MySQL. It can produce GTFS from the resultant database.